### PR TITLE
Fix: /data location to return user

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,7 +102,7 @@ app.get('/data',
         }
       })
 
-      res.render('data', { data: raw });
+      res.render('data', { user: req.user, data: raw });
     })
   });
 


### PR DESCRIPTION
`/data` location에서 `header`를 렌더링할 때,

이미 로그인을 했음에도 유저정보가 없어서

아래 이미지와 같이 로그인하지 않은 것처럼 렌더링됩니다.

<img width="262" alt="Screen Shot 2021-08-22 at 4 20 43 AM" src="https://user-images.githubusercontent.com/16534576/130332720-024557a2-29e0-49df-9405-d319df696dc5.png">

그래서 아래 이미지와 같이 동작하도록 수정하였습니다!

<img width="294" alt="Screen Shot 2021-08-22 at 4 22 35 AM" src="https://user-images.githubusercontent.com/16534576/130332775-c589f270-709f-48cd-a85a-713d77a3623d.png">
